### PR TITLE
Added a section in the examples for osquery and Elasticsearch

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,3 +29,4 @@
     * [Simple Python Destination](chapters/chapter_5/section_1.md)
     * [Simple Java Destination](chapters/chapter_5/section_2.md)
     * [Python Kafka Destination](chapters/chapter_5/section_3.md)
+    * [Osquery and Elasticsearch](chapters/chapter_5/section_4.md)

--- a/chapters/chapter_5/README.md
+++ b/chapters/chapter_5/README.md
@@ -8,3 +8,5 @@ In this chapter we would like to provide you with tutorials and code examples fo
 
 * **Writing a Kafka Module in Python** Tutorial for implementing a python destination which sends messages to Apache Kafka
 
+* **Osquery and Elasticsearch** Tutorial for first sending messages from osquery to syslog-ng, and then from syslog-ng to Elasticsearch.
+

--- a/chapters/chapter_5/section_4.md
+++ b/chapters/chapter_5/section_4.md
@@ -1,0 +1,115 @@
+# Osquery and Elasticsearch
+
+Osquery is a cross-platform system monitoring tool that exposes information about a system through a SQL interface. Elasticsearch is a distributed schema-free search server based on Lucene. In this tutorial, you will learn first how to send osquery logs to syslog, and then send those logs to Elasticsearch.
+
+##Osquery
+
+### Osquery reporting
+Osquery runs in two modes - osqueryi, an interctive mode, and osqueryd, a daemon mode. Osquery's daemon mode allows for scheduled configurable queries to be run without user interaction. Conveniently, osqueryd natively supports sending the result of its scheduled queries to syslog in a JSON format. 
+
+To quickly setup osqueryd, once installed, copy its example config file "osquery.example.conf" (in my system located in /usr/share/osquery/) to "/etc/osquery/osquery.conf". Once copied, we must set the logger plugin in the osquery config file from file to syslog. We can do this by changing the line 
+
+```c
+"logger_plugin": "filesystem", 
+```
+to
+```c
+"logger_plugin": "syslog", 
+```
+
+For reference, these logs are sent with a facility of 19, or "local3". On my Ubuntu 14.04 installation, rsyslog was not logging these messages. To fix that, I added the following line to the end of my rsyslog.conf file:
+```c
+local3.* -/var/log/syslog
+```
+
+
+
+
+###The syslog-ng config file
+
+To gather the logs from osquery, all that is needed is a source which collects system messages, and a filter which can identify logs from osqueryd.
+
+An example of such a source is:
+
+```c
+source s_local {
+        system();
+};
+
+```
+An example of such a filter is:
+```c
+filter osqueryd {
+
+program("^osqueryd.*");
+};
+```
+
+
+##Elasticsearch
+
+
+At the time of writing, there is not an official Elasticsearch destination in the syslog-ng repo, but it will be added soon. Until then, the source for a suitable destination can be found at [https://github.com/juhaszviktor/ESDestination](https://github.com/juhaszviktor/ESDestination). Full documentation on the destination can be found there.
+
+###Requirements
+ * Elasticsearch libraries
+ * SyslogNg.jar
+ * JDK min 1.7 for building
+ * JRE min 1.7 for usage
+
+###Building
+You may need to change the directory of the relevant jar files. If you do, you can specify their locations by:
+```
+javac -classpath "/usr/lib/syslog-ng/3.6/SyslogNg.jar:/usr/share/elasticsearch/lib/elasticsearch-1.4.4.jar:/usr/share/elasticsearch/lib/log4j-1.2.17.jar" -d bin src/org/syslog_ng/elasticsearch/ElasticSearchDestination.java
+```
+###Packaging
+```
+jar -cvf ESDestination.jar -C bin .
+```
+
+###Example Config
+
+####Environment
+* In this example let's suppose, that the SyslogNg.jar is under the directory /usr/lib/syslog-ng/3.6
+* The elasticsearch libraries is under the /usr/share/elasticsearch/lib/ directory
+* The built jar file is under the /usr/local/ directory
+
+####Configuration example
+Here is a config file which takes messages from osquery and sends them to elasticsearch:
+
+```c
+@version: 3.6
+
+options {
+  threaded(yes);
+  use_rcptid(yes);
+};
+
+source s_local {
+        system();
+};
+
+filter osqueryd {
+
+program("^osqueryd.*");
+};
+
+
+destination d_es {
+  java(
+    class_path("/usr/local/ESDestination.jar:/usr/share/elasticsearch/lib/*.jar")
+    class_name("org.syslog_ng.elasticsearch.ElasticSearchDestination")
+    option("index", "syslog-ng_${YEAR}.${MONTH}.${DAY}")
+    option("type", "test")
+    option("cluster", "syslog-ng")
+    option("flush_limit", "100")
+  );
+};
+
+log {
+  source(s_local);
+  filter(osqueryd);
+  destination(d_es);
+  flags(flow-control);
+};
+```


### PR DESCRIPTION
Created an example for sending syslog messages from osquery, filtering only those osquery messages, and then sending them to elasticsearch. 
