### PR TITLE
chapter5: pythondd syntax update

### DIFF
--- a/chapters/chapter_5/section_1.md
+++ b/chapters/chapter_5/section_1.md
@@ -14,7 +14,7 @@ destination d_python_to_file {
         class("pythonexample.TextDestination")
         on-error("fallback-to-string")
         value-pairs(scope(everything))
-        options(my_sample_option("option_value"))
+        options(my_sample_option option_value)
     );
 };
 ```
@@ -173,7 +173,7 @@ destination d_python_to_file {
         class("pythonexample.TextDestination")
         on-error("fallback-to-string")
         value-pairs(scope(everything))
-        options(my_sample_option("option_value"))
+        options(my_sample_option option_value)
     );
 };
 


### PR DESCRIPTION
After [syslog-ng: PR: 1958](https://github.com/balabit/syslog-ng/pull/1958), syntax of python dd 'options' is changed. Changing the documents according to that.